### PR TITLE
fix csr version with openssl upgrade

### DIFF
--- a/src/certs/csr.rs
+++ b/src/certs/csr.rs
@@ -162,7 +162,7 @@ pub fn generate_csr(
     let name = extract_name_from_csr(csr)?;
 
     let mut builder = X509Req::builder()?;
-    builder.set_version(2)?;
+    builder.set_version(0)?;
     builder.set_subject_name(&name)?;
     builder.set_pubkey(&pkey)?;
 


### PR DESCRIPTION
See recent issue here:
https://github.com/ruby/openssl/issues/734
and a fix by them here:
https://github.com/ruby/openssl/pull/747
Apparently the version can only be 1, encoded as "0", but we have version 2 here.

We merged in a PR recently into lit-assets (about 6 weeks ago) that updated the openssl version from 0.10.42 to 0.10.71 here that might've broken things:
[https://github.com/LIT-Protocol/lit-assets/commit/ad0e2b149794f3e0eb1dd575ab62be794d00fc9a#diff-324027d2dc04542b5a4312[…]360ae11b6cdca2b28c382600L30](https://github.com/LIT-Protocol/lit-assets/commit/ad0e2b149794f3e0eb1dd575ab62be794d00fc9a#diff-324027d2dc04542b5a4312b99aa9ce058f7a72cd360ae11b6cdca2b28c382600L30) (edited)